### PR TITLE
Disable PdbConverter

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,5 +6,6 @@
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
     <UsingToolSymbolUploader>false</UsingToolSymbolUploader>
+    <UsingToolPdbConverter>false</UsingToolPdbConverter>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Disabling PdbConverter as it isn't used today, to work-around
https://github.com/dotnet/arcade/pull/4515.

cc @safern 