### PR TITLE
Add publishing.props configuration file

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- Tells Arcade SDK to not assume that .nupkg contains Portable PDBs -->
+    <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/4519

As tested here: https://github.com/dotnet/runtime-assets/pull/68 adding this configuration file + the sdk created in this other PR: https://github.com/dotnet/arcade/pull/5185 fixes the problem you're having with symbol publishing.