### PR TITLE
Add Content BuildAction

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,6 +44,7 @@
     <None Include="**/*"
           Exclude="$(MSBuildProjectName)$(MSBuildProjectExtension)"
           Pack="true"
+          BuildAction="Content"
           PackageCopyToOutput="true"
           PackagePath="contentFiles/any/any/"
           PackageFlatten="false" />


### PR DESCRIPTION
Without specifying the build action, content items are added to the `None` msbuild item when the nuget generated props and targets are loaded.