### PR TITLE
add a target that updates to latest

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -3,14 +3,12 @@ name: Update TimeZone Database
 on:
   schedule:
     - cron: '0 0 * * 0'
-    branches: [ main ]
 
   workflow_dispatch:
 
 jobs:
   update:
     runs-on: ubuntu-latest
-    if: github.event_name != 'schedule' || github.repository_owner == 'dotnet'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -34,7 +32,7 @@ jobs:
         with:
           script: |
             const pull = await github.pulls.create({
-              base: "main",
+              base: contex.ref,
               head: "update-from-IANA",
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -3,6 +3,9 @@ name: Check TimeZone Version
 on:
   schedule:
     - cron: '0 0 * * 0'
+    branches: [ main ]
+
+  workflow_dispatch:
 
 jobs:
   build:
@@ -12,9 +15,13 @@ jobs:
       - name: Build with dotnet
         run: ./dotnet.sh build src/System.Runtime.TimeZoneData /t:UpdateToLatestVersion
       - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v3    
-        with: 
-          title: Update IANA Timezone version
-          branch: auto-update-tz-ver
-          delete-branch: true   
+        id: pr
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
+          echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
+          git checkout -b update-from-IANA
+          git add src/System.Runtime.TimeZoneData
+          git commit -m "Automatic tzdb update from IANA"
+          git push --set-upstream origin update-from-IANA
+          gh pr create -t "TimeZone update from IANA" -b "Update the TimeZone database from IANA"

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -18,13 +18,16 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
           git checkout -b update-from-IANA
+
       - name: Run UpdateToLatestVersion
         run: ./dotnet.sh build src/System.Runtime.TimeZoneData /t:UpdateToLatestVersion
+
       - name: Commit Update
         run: |
           git add src/System.Runtime.TimeZoneData
           git commit -m "Automated update of IANA timezone data"
           git push --set-upstream origin update-from-IANA
+
       - name: Create PR
         uses: actions/github-script@v3
         with:
@@ -37,7 +40,6 @@ jobs:
               title: '🕑🕒🕓 Time zone update',
               body: 'IANA has updated tzdb'
             });
-            console.log(JSON.stringify(pull));
             github.pulls.requestReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,4 +1,4 @@
-name: Check TimeZone Version
+name: Update TimeZone Database
 
 on:
   schedule:
@@ -8,20 +8,40 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-20.04
+  update:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Build with dotnet
-        run: ./dotnet.sh build src/System.Runtime.TimeZoneData /t:UpdateToLatestVersion
-      - name: Create Pull Request
-        id: pr
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Branch
         run: |
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
-          echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
           git checkout -b update-from-IANA
+      - name: Run UpdateToLatestVersion
+        run: ./dotnet.sh build src/System.Runtime.TimeZoneData /t:UpdateToLatestVersion
+      - name: Commit Update
+        run: |
           git add src/System.Runtime.TimeZoneData
-          git commit -m "Automatic tzdb update from IANA"
+          git commit -m "Automated update of IANA timezone data"
           git push --set-upstream origin update-from-IANA
-          gh pr create -t "TimeZone update from IANA" -b "Update the TimeZone database from IANA"
+      - name: Create PR
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const pull = await github.pulls.create({
+              base: "main",
+              head: "update-from-IANA",
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '🕑🕒🕓 Time zone update',
+              body: 'IANA has updated tzdb'
+            });
+            console.log(JSON.stringify(pull));
+            github.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pull.data.number,
+              reviewers: ["lewing", "tqiu8"]
+            });
+            return pull.data.number;

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,24 @@
+name: Check TimeZone Version
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.102
+      - name: Build with dotnet
+        run: dotnet build src/System.Runtime.TimeZoneData /t:UpdateToLatestVersion
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3    
+        with: 
+          title: Update IANA Timezone version
+          branch: auto-update-tz-ver
+          delete-branch: true   

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.repository_owner == 'dotnet'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -9,12 +9,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 5.0.102
       - name: Build with dotnet
-        run: dotnet build src/System.Runtime.TimeZoneData /t:UpdateToLatestVersion
+        run: ./dotnet.sh build src/System.Runtime.TimeZoneData /t:UpdateToLatestVersion
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v3    

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -40,7 +40,7 @@ jobs:
               title: '🕑🕒🕓 Time zone update',
               body: 'IANA has updated tzdb'
             });
-            github.pulls.requestReviewers({
+            await github.pulls.requestReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: pull.data.number,

--- a/dotnet.cmd
+++ b/dotnet.cmd
@@ -1,0 +1,22 @@
+@echo off
+
+powershell -ExecutionPolicy ByPass -NoProfile -Command "& { . '%~dp0eng\common\tools.ps1'; InitializeDotNetCli $true $true }"
+
+if NOT [%ERRORLEVEL%] == [0] (
+  echo Failed to install or invoke dotnet... 1>&2
+  exit /b %ERRORLEVEL%
+)
+
+set /p dotnetPath=<%~dp0artifacts\toolset\sdk.txt
+
+:: Clear the 'Platform' env variable for this session, as it's a per-project setting within the build, and
+:: misleading value (such as 'MCD' in HP PCs) may lead to build breakage (issue: #69).
+set Platform=
+
+:: Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
+set DOTNET_MULTILEVEL_LOOKUP=0
+
+:: Disable first run since we want to control all package sources
+set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+call "%dotnetPath%\dotnet.exe" %*

--- a/dotnet.sh
+++ b/dotnet.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+source="${BASH_SOURCE[0]}"
+# resolve $SOURCE until the file is no longer a symlink
+while [[ -h $source ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+
+  # if $source was a relative symlink, we need to resolve it relative to the path where the
+  # symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+
+# Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
+export DOTNET_MULTILEVEL_LOOKUP=0
+
+# Disable first run since we want to control all package sources
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+source $scriptroot/eng/common/tools.sh
+
+InitializeDotNetCli true # Install
+__dotnetDir=${_InitializeDotNetCli}
+
+dotnetPath=${__dotnetDir}/dotnet
+${dotnetPath} "$@"

--- a/src/System.Runtime.TimeZoneData/System.Runtime.TimeZoneData.csproj
+++ b/src/System.Runtime.TimeZoneData/System.Runtime.TimeZoneData.csproj
@@ -46,10 +46,6 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="CheckVersion" DependsOnTargets="GetLatestVersion">
-    <Warning Text="TimeZoneDataVersion does not match https://data.iana.org/time-zones/tzdb/version" Condition="'$(TimeZoneDataVersion)' != '$(LatestTimeZoneDataVersion)'" />
-  </Target>
-
   <Target Name="UpdateData">
     <RemoveDir Directories="$(TimeZoneDataSrcDir)" />
     <Exec Command="wget -r -nH --cut-dirs=2 --no-parent --reject='index.html*' -P $(TimeZoneDataIntermediateDir) https://data.iana.org/time-zones/tzdb-$(TimeZoneDataVersion)/" />

--- a/src/System.Runtime.TimeZoneData/System.Runtime.TimeZoneData.csproj
+++ b/src/System.Runtime.TimeZoneData/System.Runtime.TimeZoneData.csproj
@@ -21,7 +21,12 @@
   <Target Name="SetLatestVersion" DependsOnTargets="GetLatestVersion">
     <PropertyGroup>
       <TimeZoneDataVersion>$(LatestTimeZoneDataVersion)</TimeZoneDataVersion>
+      <_TZPropName>TimeZoneDataVersion</_TZPropName>
     </PropertyGroup>
+    <WriteLinesToFile
+      File="$(MSBuildProjectFile)"
+      Lines="$([System.Text.RegularExpressions.Regex]::Replace($([System.IO.File]::ReadAllText('$(MSBuildProjectFile)')), '&lt;$(_TZPropName)&gt;[^$]*&lt;/$(_TZPropName)&gt;','&lt;$(_TZPropName)&gt;$(TimeZoneDataVersion)&lt;/$(_TZPropName)&gt;'))"
+      Overwrite="true"/>
   </Target>
   
   <Target Name="GetLatestVersion" BeforeTargets="PrepareForBuild">
@@ -63,13 +68,5 @@
     <Exec Command="find . ! -name zone.tab -maxdepth 1 -type f -exec rm -f {} +" WorkingDirectory="$(TimeZoneDataSrcDir)"/>
   </Target>
 
-  <Target Name="UpdateToLatestVersion" DependsOnTargets="SetLatestVersion;CompileTimeZoneData">
-    <PropertyGroup>
-      <_TZPropName>TimeZoneDataVersion</_TZPropName>
-    </PropertyGroup>
-    <WriteLinesToFile
-      File="$(MSBuildProjectFile)"
-      Lines="$([System.Text.RegularExpressions.Regex]::Replace($([System.IO.File]::ReadAllText('$(MSBuildProjectFile)')), '&lt;$(_TZPropName)&gt;[^$]*&lt;/$(_TZPropName)&gt;','&lt;$(_TZPropName)&gt;$(TimeZoneDataVersion)&lt;/$(_TZPropName)&gt;'))"
-      Overwrite="true"/>
-  </Target>
+  <Target Name="UpdateToLatestVersion" DependsOnTargets="SetLatestVersion;CompileTimeZoneData"/>
 </Project>

--- a/src/System.Runtime.TimeZoneData/System.Runtime.TimeZoneData.csproj
+++ b/src/System.Runtime.TimeZoneData/System.Runtime.TimeZoneData.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Build.NoTargets">
-  <Import Project="Versions.props"/>
   <PropertyGroup>
+    <TimeZoneDataVersion>2021a</TimeZoneDataVersion>
     <TimeZoneDataIntermediateDir>$([MSBuild]::NormalizeDirectory('$(IntermediateOutputPath)', 'timezonedata'))</TimeZoneDataIntermediateDir>
     <TimeZoneDataSrcDir>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', 'data'))</TimeZoneDataSrcDir>
     <ZicBloat>slim</ZicBloat>
@@ -42,7 +42,7 @@
   </Target>
 
   <Target Name="CheckVersion" DependsOnTargets="GetLatestVersion">
-    <Warning Text="TimeZoneDataVersion does not match https://data.iana.org/time-zones/tzdb/version" Condition="'$(LatestTimeZoneDataVersion)' != '$(TimeZoneDataVersion)'" />
+    <Warning Text="TimeZoneDataVersion does not match https://data.iana.org/time-zones/tzdb/version" Condition="'$(TimeZoneDataVersion)' != '$(LatestTimeZoneDataVersion)'" />
   </Target>
 
   <Target Name="UpdateData">
@@ -63,8 +63,13 @@
     <Exec Command="find . ! -name zone.tab -maxdepth 1 -type f -exec rm -f {} +" WorkingDirectory="$(TimeZoneDataSrcDir)"/>
   </Target>
 
-  <Target Name="UpdateToLatestVersion" DependsOnTargets="SetLatestVersion">
-    <CallTarget Targets="CompileTimeZoneData"/>
-    <XmlPoke XmlInputPath="Versions.props" Value="$(LatestTimeZoneDataVersion)" Query="/Project/PropertyGroup/TimeZoneDataVersion" />
+  <Target Name="UpdateToLatestVersion" DependsOnTargets="SetLatestVersion;CompileTimeZoneData">
+    <PropertyGroup>
+      <_TZPropName>TimeZoneDataVersion</_TZPropName>
+    </PropertyGroup>
+    <WriteLinesToFile
+      File="$(MSBuildProjectFile)"
+      Lines="$([System.Text.RegularExpressions.Regex]::Replace($([System.IO.File]::ReadAllText('$(MSBuildProjectFile)')), '&lt;$(_TZPropName)&gt;[^$]*&lt;/$(_TZPropName)&gt;','&lt;$(_TZPropName)&gt;$(TimeZoneDataVersion)&lt;/$(_TZPropName)&gt;'))"
+      Overwrite="true"/>
   </Target>
 </Project>

--- a/src/System.Runtime.TimeZoneData/System.Runtime.TimeZoneData.csproj
+++ b/src/System.Runtime.TimeZoneData/System.Runtime.TimeZoneData.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Build.NoTargets">
+  <Import Project="Versions.props"/>
   <PropertyGroup>
-    <TimeZoneDataVersion>2021a</TimeZoneDataVersion>
     <TimeZoneDataIntermediateDir>$([MSBuild]::NormalizeDirectory('$(IntermediateOutputPath)', 'timezonedata'))</TimeZoneDataIntermediateDir>
     <TimeZoneDataSrcDir>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', 'data'))</TimeZoneDataSrcDir>
     <ZicBloat>slim</ZicBloat>
@@ -18,7 +18,13 @@
     <Area Include="backward" />
   </ItemGroup>
 
-  <Target Name="CheckVersion">
+  <Target Name="SetLatestVersion" DependsOnTargets="GetLatestVersion">
+    <PropertyGroup>
+      <TimeZoneDataVersion>$(LatestTimeZoneDataVersion)</TimeZoneDataVersion>
+    </PropertyGroup>
+  </Target>
+  
+  <Target Name="GetLatestVersion" BeforeTargets="PrepareForBuild">
     <DownloadFile SourceUrl="https://data.iana.org/time-zones/tzdb/version"
                   DestinationFolder="$(TimeZoneDataIntermediateDir)">
       <Output TaskParameter="DownloadedFile" ItemName="VersionFile" />
@@ -30,8 +36,13 @@
     <ItemGroup>
       <FileWrites Include="@(VersionFile)" />
     </ItemGroup>
+    <PropertyGroup>
+      <LatestTimeZoneDataVersion>@(VersionLines)</LatestTimeZoneDataVersion>
+    </PropertyGroup>
+  </Target>
 
-    <Warning Text="TimeZoneDataVerson does not match https://data.iana.org/time-zones/tzdb/version" Condition="'@(VersionLines)' != '$(TimeZoneDataVersion)'" />
+  <Target Name="CheckVersion" DependsOnTargets="GetLatestVersion">
+    <Warning Text="TimeZoneDataVersion does not match https://data.iana.org/time-zones/tzdb/version" Condition="'$(LatestTimeZoneDataVersion)' != '$(TimeZoneDataVersion)'" />
   </Target>
 
   <Target Name="UpdateData">
@@ -43,12 +54,17 @@
                   DestinationFileName="zone.tab" />
   </Target>
 
-  <Target Name="CompileZic" AfterTargets="UpdateData">
+  <Target Name="CompileZic" DependsOnTargets="UpdateData">
     <Exec Command="make zic" WorkingDirectory="$(TimeZoneDataIntermediateDir)"/>
   </Target>
 
-  <Target Name="CompileTimeZoneData" AfterTargets="CompileZic">
+  <Target Name="CompileTimeZoneData" DependsOnTargets="CompileZic">
     <Exec Command="./zic -d $(TimeZoneDataSrcDir) -b $(ZicBloat) %(Area.Identity)" WorkingDirectory="$(TimeZoneDataIntermediateDir)"/>
     <Exec Command="find . ! -name zone.tab -maxdepth 1 -type f -exec rm -f {} +" WorkingDirectory="$(TimeZoneDataSrcDir)"/>
+  </Target>
+
+  <Target Name="UpdateToLatestVersion" DependsOnTargets="SetLatestVersion">
+    <CallTarget Targets="CompileTimeZoneData"/>
+    <XmlPoke XmlInputPath="Versions.props" Value="$(LatestTimeZoneDataVersion)" Query="/Project/PropertyGroup/TimeZoneDataVersion" />
   </Target>
 </Project>

--- a/src/System.Runtime.TimeZoneData/Versions.props
+++ b/src/System.Runtime.TimeZoneData/Versions.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <TimeZoneDataVersion>2021a</TimeZoneDataVersion>
+  </PropertyGroup>
+</Project>

--- a/src/System.Runtime.TimeZoneData/Versions.props
+++ b/src/System.Runtime.TimeZoneData/Versions.props
@@ -1,5 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <TimeZoneDataVersion>2021a</TimeZoneDataVersion>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
Adds some targets to automatically update to the lastest tzdb version so that https://github.com/dotnet/runtime-assets/pull/96 can be updated to open a full update pr 