### PR TITLE
Add test date for Numerics

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -73,3 +73,18 @@ this LICENSE file) are in the public domain.
 
 If the files date.c, newstrftime.3, and strftime.c are present, they
 contain material derived from BSD and use the BSD 3-clause license.
+
+
+License for ibm-fpgen (https://github.com/nigeltao/parse-number-fxx-test-data)
+--------------------------------------
+
+   Copyright 2018 Daniel Lemire
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/System.Runtime.Numerics.TestData/System.Runtime.Numerics.TestData.csproj
+++ b/src/System.Runtime.Numerics.TestData/System.Runtime.Numerics.TestData.csproj
@@ -1,0 +1,1 @@
+<Project Sdk="Microsoft.Build.NoTargets" />

--- a/src/System.Runtime.NumericsTestData/System.Runtime.NumericsTestData.csproj
+++ b/src/System.Runtime.NumericsTestData/System.Runtime.NumericsTestData.csproj
@@ -1,0 +1,1 @@
+<Project Sdk="Microsoft.Build.NoTargets" />

--- a/src/System.Runtime.NumericsTestData/System.Runtime.NumericsTestData.csproj
+++ b/src/System.Runtime.NumericsTestData/System.Runtime.NumericsTestData.csproj
@@ -1,1 +1,0 @@
-<Project Sdk="Microsoft.Build.NoTargets" />


### PR DESCRIPTION
Adding test data to run unit tests for our parse routine in dotnet/runtime. Related to https://github.com/dotnet/runtime/pull/50394/files

Not sure who the right peeps are for this repo. 