### PR TITLE
[release/5.0] Fix typo in vmimage in azure-pipelines.yml 

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -63,7 +63,7 @@ stages:
       - ${{ if eq(variables._RunAsPublic, True) }}:
         - job: Linux
           pool:
-            vimage: 'ubuntu-latest'
+            vmimage: 'ubuntu-latest'
           strategy:
             matrix:
               Build_Debug:


### PR DESCRIPTION
This causes it to not select the ubuntu-latest queue and running on the deprecated Ubuntu16 queue instead (which is hitting a scheduled brownout right now).

Backport of #170