### PR TITLE
[release/6.0 ]Rename namespace of Mono.Cecil to avoid clash

### DIFF
--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/BaseImageVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/BaseImageVisitor.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal abstract class BaseImageVisitor : IBinaryVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/CLIHeader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/CLIHeader.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal sealed class CLIHeader : IHeader, IBinaryVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/CopyImageVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/CopyImageVisitor.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	sealed class CopyImageVisitor : BaseImageVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/DOSHeader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/DOSHeader.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal sealed class DOSHeader : IHeader, IBinaryVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/DataDirectory.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/DataDirectory.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal struct DataDirectory {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/DebugHeader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/DebugHeader.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/DebugStoreType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/DebugStoreType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal enum DebugStoreType : uint {
 		Unknown = 0x00000000,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ExportTable.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ExportTable.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal sealed class ExportTable : IBinaryVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/IBinaryVisitable.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/IBinaryVisitable.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal interface IBinaryVisitable {
 		void Accept (IBinaryVisitor visitor);

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/IBinaryVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/IBinaryVisitor.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal interface IBinaryVisitor {
 		void VisitImage (Image img);

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/IHeader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/IHeader.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal interface IHeader {
 		void SetDefaultValues ();

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/Image.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/Image.cs
@@ -26,12 +26,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	using System;
 	using System.IO;
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class Image : IBinaryVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ImageCharacteristics.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ImageCharacteristics.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ImageFormatException.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ImageFormatException.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ImageInitializer.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ImageInitializer.cs
@@ -26,11 +26,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	using System;
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	sealed class ImageInitializer : BaseImageVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ImageReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ImageReader.cs
@@ -26,13 +26,13 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	using System;
 	using System.IO;
 	using System.Text;
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	sealed class ImageReader : BaseImageVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ImageWriter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ImageWriter.cs
@@ -26,12 +26,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	using System.IO;
 	using System.Text;
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	sealed class ImageWriter : BaseImageVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/Imports.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/Imports.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal sealed class ImportAddressTable : IBinaryVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/MemoryBinaryWriter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/MemoryBinaryWriter.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	using System.IO;
 	using System.Text;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/PEFileHeader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/PEFileHeader.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal sealed class PEFileHeader : IHeader, IBinaryVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/PEOptionalHeader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/PEOptionalHeader.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal sealed class PEOptionalHeader : IHeader, IBinaryVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/RVA.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/RVA.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal struct RVA {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceDataEntry.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceDataEntry.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal class ResourceDataEntry : ResourceNode {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceDirectoryEntry.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceDirectoryEntry.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal class ResourceDirectoryEntry : ResourceNode {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceDirectoryString.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceDirectoryString.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal class ResourceDirectoryString : ResourceNode {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceDirectoryTable.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceDirectoryTable.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	using System.Collections;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceNode.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceNode.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal abstract class ResourceNode {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceReader.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	using System;
 	using System.IO;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceWriter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/ResourceWriter.cs
@@ -28,7 +28,7 @@
 
 using System.Text;
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	using System.Collections;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/RuntimeImage.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/RuntimeImage.cs
@@ -28,7 +28,7 @@
 
 using System;
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	[Flags]
 	internal enum RuntimeImage : uint {

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/Section.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/Section.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal sealed class Section : IHeader, IBinaryVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/SectionCharacteristics.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/SectionCharacteristics.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/SectionCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/SectionCollection.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/SubSystem.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/SubSystem.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Binary {
+namespace CilStrip.Mono.Cecil.Binary {
 
 	internal enum SubSystem : ushort {
 		Unknown = 0x0,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/BaseCodeVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/BaseCodeVisitor.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal abstract class BaseCodeVisitor : ICodeVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/CilWorker.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/CilWorker.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 	using SR = System.Reflection;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/Code.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/Code.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal enum Code {
 		Nop,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/CodeReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/CodeReader.cs
@@ -26,15 +26,15 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 	using System.Collections;
 	using System.IO;
 
-	using Mono.Cecil;
-	using Mono.Cecil.Metadata;
-	using Mono.Cecil.Signatures;
+	using CilStrip.Mono.Cecil;
+	using CilStrip.Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Signatures;
 
 	sealed class CodeReader : BaseCodeVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/CodeWriter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/CodeWriter.cs
@@ -26,15 +26,15 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil;
-	using Mono.Cecil.Binary;
-	using Mono.Cecil.Metadata;
-	using Mono.Cecil.Signatures;
+	using CilStrip.Mono.Cecil;
+	using CilStrip.Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Signatures;
 
 	sealed class CodeWriter : BaseCodeVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/Document.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/Document.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/DocumentHashAlgorithm.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/DocumentHashAlgorithm.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal enum DocumentHashAlgorithm {
 		[Guid (0x00000000, 0x0000, 0x0000, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)] None,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/DocumentLanguage.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/DocumentLanguage.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/DocumentLanguageVendor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/DocumentLanguageVendor.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/DocumentType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/DocumentType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ExceptionHandler.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ExceptionHandler.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class ExceptionHandler : ICodeVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ExceptionHandlerCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ExceptionHandlerCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class ExceptionHandlerCollection : CollectionBase, ICodeVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ExceptionHandlerType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ExceptionHandlerType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal enum ExceptionHandlerType {
 		Catch = 0x0000,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/FlowControl.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/FlowControl.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal enum FlowControl {
 		Branch,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/GuidAttribute.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/GuidAttribute.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 	using System.Reflection;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ICodeVisitable.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ICodeVisitable.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal interface ICodeVisitable {
 		void Accept (ICodeVisitor visitor);

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ICodeVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ICodeVisitor.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal interface ICodeVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/IScopeProvider.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/IScopeProvider.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal interface IScopeProvider {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ISymbolReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ISymbolReader.cs
@@ -29,7 +29,7 @@
 using System;
 using System.Collections;
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal interface ISymbolReader : IDisposable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ISymbolStoreFactory.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ISymbolStoreFactory.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal interface ISymbolStoreFactory {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ISymbolWriter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ISymbolWriter.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/IVariableDefinitionProvider.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/IVariableDefinitionProvider.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal interface IVariableDefinitionProvider {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/Instruction.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/Instruction.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal sealed class Instruction : ICodeVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/InstructionCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/InstructionCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class InstructionCollection : CollectionBase, ICodeVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/MethodBody.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/MethodBody.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class MethodBody : IVariableDefinitionProvider, IScopeProvider, ICodeVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/MethodDataSection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/MethodDataSection.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal enum MethodDataSection : ushort {
 		EHTable = 0x1,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/MethodHeader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/MethodHeader.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal enum MethodHeader : ushort {
 		TinyFormat = 0x2,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/OpCode.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/OpCode.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal struct OpCode {
 		short m_value;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/OpCodeNames.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/OpCodeNames.cs
@@ -24,7 +24,7 @@
 // copy-pasted from /mcs/class/corlib/System.Reflection.Emit/OpCodeNames.cs
 // added names for "no." and "readonly."
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal sealed class OpCodeNames {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/OpCodeType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/OpCodeType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal enum OpCodeType {
 		Annotation,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/OpCodes.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/OpCodes.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal sealed class OpCodes {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/OperandType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/OperandType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal enum OperandType {
 		InlineBrTarget,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/Scope.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/Scope.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal class Scope : IScopeProvider, IVariableDefinitionProvider, ICodeVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ScopeCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/ScopeCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class ScopeCollection : CollectionBase, ICodeVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/SequencePoint.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/SequencePoint.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal class SequencePoint {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/StackBehaviour.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/StackBehaviour.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal enum StackBehaviour {
 		Pop0,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/SymbolStoreHelper.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/SymbolStoreHelper.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 	using SR = System.Reflection;
@@ -78,7 +78,7 @@ namespace Mono.Cecil.Cil {
 		static string GetSymbolSupportType (out string assembly)
 		{
 			string kind = GetSymbolKind ();
-			assembly = "Mono.Cecil." + kind;
+			assembly = "CilStrip.Mono.Cecil." + kind;
 			return string.Format (assembly + "." + kind + "Factory");
 		}
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/VariableDefinition.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/VariableDefinition.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal sealed class VariableDefinition : VariableReference {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/VariableDefinitionCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/VariableDefinitionCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class VariableDefinitionCollection : CollectionBase, ICodeVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/VariableReference.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Cil/VariableReference.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Cil {
+namespace CilStrip.Mono.Cecil.Cil {
 
 	internal abstract class VariableReference : ICodeVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Assembly.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Assembly.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class AssemblyTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/AssemblyOS.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/AssemblyOS.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class AssemblyOSTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/AssemblyProcessor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/AssemblyProcessor.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class AssemblyProcessorTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/AssemblyRef.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/AssemblyRef.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class AssemblyRefTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/AssemblyRefOS.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/AssemblyRefOS.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class AssemblyRefOSTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/AssemblyRefProcessor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/AssemblyRefProcessor.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class AssemblyRefProcessorTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/BaseMetadataVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/BaseMetadataVisitor.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal abstract class BaseMetadataVisitor : IMetadataVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/BlobHeap.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/BlobHeap.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ClassLayout.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ClassLayout.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class ClassLayoutTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/CodedIndex.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/CodedIndex.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal enum CodedIndex {
 		TypeDefOrRef,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Constant.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Constant.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class ConstantTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/CultureUtils.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/CultureUtils.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/CustomAttribute.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/CustomAttribute.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class CustomAttributeTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/DeclSecurity.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/DeclSecurity.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class DeclSecurityTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ElementType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ElementType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal enum ElementType {
 		End		 = 0x00,   // Marks end of a list

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Event.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Event.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class EventTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/EventMap.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/EventMap.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class EventMapTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/EventPtr.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/EventPtr.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class EventPtrTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ExportedType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ExportedType.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class ExportedTypeTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Field.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Field.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class FieldTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/FieldLayout.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/FieldLayout.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class FieldLayoutTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/FieldMarshal.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/FieldMarshal.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class FieldMarshalTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/FieldPtr.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/FieldPtr.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class FieldPtrTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/FieldRVA.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/FieldRVA.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Binary;
 
 	internal sealed class FieldRVATable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/File.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/File.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class FileTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/GenericParam.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/GenericParam.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class GenericParamTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/GenericParamConstraint.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/GenericParamConstraint.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class GenericParamConstraintTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/GuidHeap.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/GuidHeap.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/IMetadataRow.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/IMetadataRow.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal interface IMetadataRow : IMetadataRowVisitable {
 	}

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/IMetadataTable.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/IMetadataTable.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal interface IMetadataTable : IMetadataTableVisitable {
 		int Id { get; }

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/IMetadataVisitable.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/IMetadataVisitable.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal interface IMetadataVisitable {
 		void Accept (IMetadataVisitor visitor);

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/IMetadataVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/IMetadataVisitor.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal interface IMetadataVisitor {
 		void VisitMetadataRoot (MetadataRoot root);

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ImplMap.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ImplMap.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class ImplMapTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/InterfaceImpl.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/InterfaceImpl.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class InterfaceImplTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ManifestResource.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ManifestResource.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class ManifestResourceTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MemberRef.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MemberRef.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class MemberRefTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataFormatException.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataFormatException.cs
@@ -26,11 +26,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 
-	using Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Binary;
 
 	internal class MetadataFormatException : ImageFormatException {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataHeap.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataHeap.cs
@@ -26,11 +26,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal abstract class MetadataHeap : IMetadataVisitable  {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataInitializer.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataInitializer.cs
@@ -26,14 +26,14 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.IO;
 	using System.Text;
 
-	using Mono.Cecil;
-	using Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil;
+	using CilStrip.Mono.Cecil.Binary;
 
 	sealed class MetadataInitializer : BaseMetadataVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataReader.cs
@@ -26,13 +26,13 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.IO;
 	using System.Text;
 
-	using Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Binary;
 
 	sealed class MetadataReader : BaseMetadataVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataRoot.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataRoot.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Binary;
 
 	internal sealed class MetadataRoot : IMetadataVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataRowReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataRowReader.cs
@@ -29,13 +29,13 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.Collections;
 	using System.IO;
 
-	using Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Binary;
 
 	sealed class MetadataRowReader : BaseMetadataRowVisitor {
 
@@ -92,12 +92,12 @@ namespace Mono.Cecil.Metadata {
 
 		public override void VisitAssemblyRow (AssemblyRow row)
 		{
-			row.HashAlgId = (Mono.Cecil.AssemblyHashAlgorithm) m_binaryReader.ReadUInt32 ();
+			row.HashAlgId = (CilStrip.Mono.Cecil.AssemblyHashAlgorithm) m_binaryReader.ReadUInt32 ();
 			row.MajorVersion = m_binaryReader.ReadUInt16 ();
 			row.MinorVersion = m_binaryReader.ReadUInt16 ();
 			row.BuildNumber = m_binaryReader.ReadUInt16 ();
 			row.RevisionNumber = m_binaryReader.ReadUInt16 ();
-			row.Flags = (Mono.Cecil.AssemblyFlags) m_binaryReader.ReadUInt32 ();
+			row.Flags = (CilStrip.Mono.Cecil.AssemblyFlags) m_binaryReader.ReadUInt32 ();
 			row.PublicKey = ReadByIndexSize (m_blobHeapIdxSz);
 			row.Name = ReadByIndexSize (m_stringsHeapIdxSz);
 			row.Culture = ReadByIndexSize (m_stringsHeapIdxSz);
@@ -118,7 +118,7 @@ namespace Mono.Cecil.Metadata {
 			row.MinorVersion = m_binaryReader.ReadUInt16 ();
 			row.BuildNumber = m_binaryReader.ReadUInt16 ();
 			row.RevisionNumber = m_binaryReader.ReadUInt16 ();
-			row.Flags = (Mono.Cecil.AssemblyFlags) m_binaryReader.ReadUInt32 ();
+			row.Flags = (CilStrip.Mono.Cecil.AssemblyFlags) m_binaryReader.ReadUInt32 ();
 			row.PublicKeyOrToken = ReadByIndexSize (m_blobHeapIdxSz);
 			row.Name = ReadByIndexSize (m_stringsHeapIdxSz);
 			row.Culture = ReadByIndexSize (m_stringsHeapIdxSz);
@@ -144,7 +144,7 @@ namespace Mono.Cecil.Metadata {
 		}
 		public override void VisitConstantRow (ConstantRow row)
 		{
-			row.Type = (Mono.Cecil.Metadata.ElementType) m_binaryReader.ReadUInt16 ();
+			row.Type = (CilStrip.Mono.Cecil.Metadata.ElementType) m_binaryReader.ReadUInt16 ();
 			row.Parent = Utilities.GetMetadataToken (CodedIndex.HasConstant,
 				ReadByIndexSize (GetCodedIndexSize (CodedIndex.HasConstant)));
 			row.Value = ReadByIndexSize (m_blobHeapIdxSz);
@@ -159,14 +159,14 @@ namespace Mono.Cecil.Metadata {
 		}
 		public override void VisitDeclSecurityRow (DeclSecurityRow row)
 		{
-			row.Action = (Mono.Cecil.SecurityAction) m_binaryReader.ReadInt16 ();
+			row.Action = (CilStrip.Mono.Cecil.SecurityAction) m_binaryReader.ReadInt16 ();
 			row.Parent = Utilities.GetMetadataToken (CodedIndex.HasDeclSecurity,
 				ReadByIndexSize (GetCodedIndexSize (CodedIndex.HasDeclSecurity)));
 			row.PermissionSet = ReadByIndexSize (m_blobHeapIdxSz);
 		}
 		public override void VisitEventRow (EventRow row)
 		{
-			row.EventFlags = (Mono.Cecil.EventAttributes) m_binaryReader.ReadUInt16 ();
+			row.EventFlags = (CilStrip.Mono.Cecil.EventAttributes) m_binaryReader.ReadUInt16 ();
 			row.Name = ReadByIndexSize (m_stringsHeapIdxSz);
 			row.EventType = Utilities.GetMetadataToken (CodedIndex.TypeDefOrRef,
 				ReadByIndexSize (GetCodedIndexSize (CodedIndex.TypeDefOrRef)));
@@ -182,7 +182,7 @@ namespace Mono.Cecil.Metadata {
 		}
 		public override void VisitExportedTypeRow (ExportedTypeRow row)
 		{
-			row.Flags = (Mono.Cecil.TypeAttributes) m_binaryReader.ReadUInt32 ();
+			row.Flags = (CilStrip.Mono.Cecil.TypeAttributes) m_binaryReader.ReadUInt32 ();
 			row.TypeDefId = m_binaryReader.ReadUInt32 ();
 			row.TypeName = ReadByIndexSize (m_stringsHeapIdxSz);
 			row.TypeNamespace = ReadByIndexSize (m_stringsHeapIdxSz);
@@ -191,7 +191,7 @@ namespace Mono.Cecil.Metadata {
 		}
 		public override void VisitFieldRow (FieldRow row)
 		{
-			row.Flags = (Mono.Cecil.FieldAttributes) m_binaryReader.ReadUInt16 ();
+			row.Flags = (CilStrip.Mono.Cecil.FieldAttributes) m_binaryReader.ReadUInt16 ();
 			row.Name = ReadByIndexSize (m_stringsHeapIdxSz);
 			row.Signature = ReadByIndexSize (m_blobHeapIdxSz);
 		}
@@ -217,14 +217,14 @@ namespace Mono.Cecil.Metadata {
 		}
 		public override void VisitFileRow (FileRow row)
 		{
-			row.Flags = (Mono.Cecil.FileAttributes) m_binaryReader.ReadUInt32 ();
+			row.Flags = (CilStrip.Mono.Cecil.FileAttributes) m_binaryReader.ReadUInt32 ();
 			row.Name = ReadByIndexSize (m_stringsHeapIdxSz);
 			row.HashValue = ReadByIndexSize (m_blobHeapIdxSz);
 		}
 		public override void VisitGenericParamRow (GenericParamRow row)
 		{
 			row.Number = m_binaryReader.ReadUInt16 ();
-			row.Flags = (Mono.Cecil.GenericParameterAttributes) m_binaryReader.ReadUInt16 ();
+			row.Flags = (CilStrip.Mono.Cecil.GenericParameterAttributes) m_binaryReader.ReadUInt16 ();
 			row.Owner = Utilities.GetMetadataToken (CodedIndex.TypeOrMethodDef,
 				ReadByIndexSize (GetCodedIndexSize (CodedIndex.TypeOrMethodDef)));
 			row.Name = ReadByIndexSize (m_stringsHeapIdxSz);
@@ -237,7 +237,7 @@ namespace Mono.Cecil.Metadata {
 		}
 		public override void VisitImplMapRow (ImplMapRow row)
 		{
-			row.MappingFlags = (Mono.Cecil.PInvokeAttributes) m_binaryReader.ReadUInt16 ();
+			row.MappingFlags = (CilStrip.Mono.Cecil.PInvokeAttributes) m_binaryReader.ReadUInt16 ();
 			row.MemberForwarded = Utilities.GetMetadataToken (CodedIndex.MemberForwarded,
 				ReadByIndexSize (GetCodedIndexSize (CodedIndex.MemberForwarded)));
 			row.ImportName = ReadByIndexSize (m_stringsHeapIdxSz);
@@ -252,7 +252,7 @@ namespace Mono.Cecil.Metadata {
 		public override void VisitManifestResourceRow (ManifestResourceRow row)
 		{
 			row.Offset = m_binaryReader.ReadUInt32 ();
-			row.Flags = (Mono.Cecil.ManifestResourceAttributes) m_binaryReader.ReadUInt32 ();
+			row.Flags = (CilStrip.Mono.Cecil.ManifestResourceAttributes) m_binaryReader.ReadUInt32 ();
 			row.Name = ReadByIndexSize (m_stringsHeapIdxSz);
 			row.Implementation = Utilities.GetMetadataToken (CodedIndex.Implementation,
 				ReadByIndexSize (GetCodedIndexSize (CodedIndex.Implementation)));
@@ -267,8 +267,8 @@ namespace Mono.Cecil.Metadata {
 		public override void VisitMethodRow (MethodRow row)
 		{
 			row.RVA = new RVA (m_binaryReader.ReadUInt32 ());
-			row.ImplFlags = (Mono.Cecil.MethodImplAttributes) m_binaryReader.ReadUInt16 ();
-			row.Flags = (Mono.Cecil.MethodAttributes) m_binaryReader.ReadUInt16 ();
+			row.ImplFlags = (CilStrip.Mono.Cecil.MethodImplAttributes) m_binaryReader.ReadUInt16 ();
+			row.Flags = (CilStrip.Mono.Cecil.MethodAttributes) m_binaryReader.ReadUInt16 ();
 			row.Name = ReadByIndexSize (m_stringsHeapIdxSz);
 			row.Signature = ReadByIndexSize (m_blobHeapIdxSz);
 			row.ParamList = ReadByIndexSize (GetIndexSize (ParamTable.RId));
@@ -287,7 +287,7 @@ namespace Mono.Cecil.Metadata {
 		}
 		public override void VisitMethodSemanticsRow (MethodSemanticsRow row)
 		{
-			row.Semantics = (Mono.Cecil.MethodSemanticsAttributes) m_binaryReader.ReadUInt16 ();
+			row.Semantics = (CilStrip.Mono.Cecil.MethodSemanticsAttributes) m_binaryReader.ReadUInt16 ();
 			row.Method = ReadByIndexSize (GetIndexSize (MethodTable.RId));
 			row.Association = Utilities.GetMetadataToken (CodedIndex.HasSemantics,
 				ReadByIndexSize (GetCodedIndexSize (CodedIndex.HasSemantics)));
@@ -317,7 +317,7 @@ namespace Mono.Cecil.Metadata {
 		}
 		public override void VisitParamRow (ParamRow row)
 		{
-			row.Flags = (Mono.Cecil.ParameterAttributes) m_binaryReader.ReadUInt16 ();
+			row.Flags = (CilStrip.Mono.Cecil.ParameterAttributes) m_binaryReader.ReadUInt16 ();
 			row.Sequence = m_binaryReader.ReadUInt16 ();
 			row.Name = ReadByIndexSize (m_stringsHeapIdxSz);
 		}
@@ -327,7 +327,7 @@ namespace Mono.Cecil.Metadata {
 		}
 		public override void VisitPropertyRow (PropertyRow row)
 		{
-			row.Flags = (Mono.Cecil.PropertyAttributes) m_binaryReader.ReadUInt16 ();
+			row.Flags = (CilStrip.Mono.Cecil.PropertyAttributes) m_binaryReader.ReadUInt16 ();
 			row.Name = ReadByIndexSize (m_stringsHeapIdxSz);
 			row.Type = ReadByIndexSize (m_blobHeapIdxSz);
 		}
@@ -346,7 +346,7 @@ namespace Mono.Cecil.Metadata {
 		}
 		public override void VisitTypeDefRow (TypeDefRow row)
 		{
-			row.Flags = (Mono.Cecil.TypeAttributes) m_binaryReader.ReadUInt32 ();
+			row.Flags = (CilStrip.Mono.Cecil.TypeAttributes) m_binaryReader.ReadUInt32 ();
 			row.Name = ReadByIndexSize (m_stringsHeapIdxSz);
 			row.Namespace = ReadByIndexSize (m_stringsHeapIdxSz);
 			row.Extends = Utilities.GetMetadataToken (CodedIndex.TypeDefOrRef,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataRowWriter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataRowWriter.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Binary;
 
 	sealed class MetadataRowWriter : BaseMetadataRowVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataStream.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataStream.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal class MetadataStream : IMetadataVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataStreamCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataStreamCollection.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataTableReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataTableReader.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataTableWriter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataTableWriter.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Binary;
 
 	internal sealed class MetadataTableWriter : BaseMetadataTableVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataToken.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataToken.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal struct MetadataToken {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataWriter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MetadataWriter.cs
@@ -26,15 +26,15 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.Collections;
 	using System.IO;
 	using System.Text;
 
-	using Mono.Cecil;
-	using Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil;
+	using CilStrip.Mono.Cecil.Binary;
 
 	internal sealed class MetadataWriter : BaseMetadataVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Method.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Method.cs
@@ -29,11 +29,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
-	using Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Binary;
 
 	internal sealed class MethodTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MethodImpl.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MethodImpl.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class MethodImplTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MethodPtr.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MethodPtr.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class MethodPtrTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MethodSemantics.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MethodSemantics.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class MethodSemanticsTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MethodSpec.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/MethodSpec.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class MethodSpecTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Module.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Module.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class ModuleTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ModuleRef.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ModuleRef.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class ModuleRefTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/NestedClass.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/NestedClass.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class NestedClassTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Param.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Param.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class ParamTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ParamPtr.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/ParamPtr.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class ParamPtrTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Property.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Property.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class PropertyTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/PropertyMap.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/PropertyMap.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class PropertyMapTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/PropertyPtr.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/PropertyPtr.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class PropertyPtrTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/RowCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/RowCollection.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/StandAloneSig.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/StandAloneSig.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class StandAloneSigTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/StringsHeap.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/StringsHeap.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System.Collections;
 	using System.Text;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/TableCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/TableCollection.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/TablesHeap.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/TablesHeap.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/TokenType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/TokenType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal enum TokenType : uint {
 		Module			  = 0x00000000,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/TypeDef.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/TypeDef.cs
@@ -29,9 +29,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class TypeDefTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/TypeRef.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/TypeRef.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class TypeRefTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/TypeSpec.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/TypeSpec.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	internal sealed class TypeSpecTable : IMetadataTable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/UserStringsHeap.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/UserStringsHeap.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System.Collections;
 	using System.Text;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Utilities.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Metadata/Utilities.cs
@@ -29,7 +29,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Metadata {
+namespace CilStrip.Mono.Cecil.Metadata {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Array.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Array.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class ARRAY : SigType {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/ArrayShape.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/ArrayShape.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal sealed class ArrayShape {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/BaseSignatureVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/BaseSignatureVisitor.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal abstract class BaseSignatureVisitor : ISignatureVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Class.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Class.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class CLASS : SigType {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Constraint.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Constraint.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal enum Constraint : byte {
 		None = 0x0,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/CustomAttrib.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/CustomAttrib.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class CustomAttrib {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/CustomMod.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/CustomMod.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class CustomMod {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/FieldSig.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/FieldSig.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal sealed class FieldSig : Signature {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/FnPtr.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/FnPtr.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class FNPTR : SigType {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/GenericArg.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/GenericArg.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	sealed class GenericArg {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/GenericInst.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/GenericInst.cs
@@ -27,10 +27,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
-	using Mono.Cecil;
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class GENERICINST : SigType {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/GenericInstSignature.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/GenericInstSignature.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal sealed class GenericInstSignature {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/ISignatureVisitable.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/ISignatureVisitable.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal interface ISignatureVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/ISignatureVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/ISignatureVisitor.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal interface ISignatureVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/InputOutputItem.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/InputOutputItem.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal abstract class InputOutputItem {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/LocalVarSig.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/LocalVarSig.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal sealed class LocalVarSig : Signature {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/MVar.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/MVar.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class MVAR : SigType {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/MarshalSig.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/MarshalSig.cs
@@ -26,11 +26,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	using System;
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal sealed class MarshalSig {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/MethodDefSig.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/MethodDefSig.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal sealed class MethodDefSig : MethodRefSig {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/MethodRefSig.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/MethodRefSig.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal class MethodRefSig : MethodSig {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/MethodSig.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/MethodSig.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using Mono.Cecil;
+using CilStrip.Mono.Cecil;
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal abstract class MethodSig : Signature {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/MethodSpec.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/MethodSpec.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal sealed class MethodSpec {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Param.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Param.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal sealed class Param : InputOutputItem {
 	}

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/PropertySig.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/PropertySig.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal sealed class PropertySig : Signature {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Ptr.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Ptr.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class PTR : SigType {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/RetType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/RetType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal sealed class RetType : InputOutputItem {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/SigType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/SigType.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal class SigType {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Signature.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Signature.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/SignatureReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/SignatureReader.cs
@@ -26,15 +26,15 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	using System;
 	using System.Collections;
 	using System.IO;
 	using System.Text;
 
-	using Mono.Cecil;
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class SignatureReader : BaseSignatureVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/SignatureWriter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/SignatureWriter.cs
@@ -26,14 +26,14 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	using System;
 	using System.Text;
 
-	using Mono.Cecil;
-	using Mono.Cecil.Binary;
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil;
+	using CilStrip.Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class SignatureWriter : BaseSignatureVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/SzArray.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/SzArray.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class SZARRAY : SigType {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/TypeSpec.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/TypeSpec.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
 	internal sealed class TypeSpec {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/ValueType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/ValueType.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class VALUETYPE : SigType {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Var.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Signatures/Var.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil.Signatures {
+namespace CilStrip.Mono.Cecil.Signatures {
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class VAR : SigType {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AggressiveReflectionReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AggressiveReflectionReader.cs
@@ -26,12 +26,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 
-	using Mono.Cecil.Metadata;
-	using Mono.Cecil.Signatures;
+	using CilStrip.Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Signatures;
 
 	internal sealed class AggressiveReflectionReader : ReflectionReader {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ArrayDimension.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ArrayDimension.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class ArrayDimension {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ArrayDimensionCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ArrayDimensionCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class ArrayDimensionCollection : CollectionBase {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ArrayType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ArrayType.cs
@@ -26,11 +26,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Text;
 
-	using Mono.Cecil.Signatures;
+	using CilStrip.Mono.Cecil.Signatures;
 
 	internal sealed class ArrayType : TypeSpecification {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyDefinition.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyDefinition.cs
@@ -26,12 +26,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal class AssemblyDefinition : ICustomAttributeProvider,
 		IHasSecurity, IAnnotationProvider, IReflectionStructureVisitable {

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyFactory.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyFactory.cs
@@ -26,13 +26,13 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.IO;
 	using SR = System.Reflection;
 
-	using Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Binary;
 
 	internal sealed class AssemblyFactory {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyFlags.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyFlags.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyHashAlgorithm.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyHashAlgorithm.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal enum AssemblyHashAlgorithm : uint {
 		None		= 0x0000,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyKind.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyKind.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal enum AssemblyKind {
 		Dll,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyLinkedResource.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyLinkedResource.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class AssemblyLinkedResource : Resource {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyNameDefinition.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyNameDefinition.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyNameReference.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyNameReference.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
@@ -34,7 +34,7 @@ namespace Mono.Cecil {
 	using System.Security.Cryptography;
 	using System.Text;
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal class AssemblyNameReference : IMetadataScope, IAnnotationProvider, IReflectionStructureVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyNameReferenceCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/AssemblyNameReferenceCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class AssemblyNameReferenceCollection : CollectionBase, IReflectionStructureVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/BaseAssemblyResolver.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/BaseAssemblyResolver.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/BaseReflectionReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/BaseReflectionReader.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal abstract class BaseReflectionReader : BaseReflectionVisitor, IDetailReader {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/BaseReflectionVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/BaseReflectionVisitor.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Collections;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/BaseStructureVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/BaseStructureVisitor.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Collections;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/CallSite.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/CallSite.cs
@@ -26,12 +26,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Collections;
 	using System.Text;
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class CallSite : IMethodSignature, IAnnotationProvider, IMetadataTokenProvider {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/Constants.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/Constants.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal class Constants {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ConstraintCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ConstraintCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class ConstraintCollection : CollectionBase {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ConstructorCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ConstructorCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class ConstructorCollection : CollectionBase, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/CustomAttribute.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/CustomAttribute.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Collections;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/CustomAttributeCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/CustomAttributeCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class CustomAttributeCollection : CollectionBase, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/DefaultAssemblyResolver.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/DefaultAssemblyResolver.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Collections;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/DefaultImporter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/DefaultImporter.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/EmbeddedResource.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/EmbeddedResource.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class EmbeddedResource : Resource {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/EventAttributes.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/EventAttributes.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/EventDefinition.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/EventDefinition.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class EventDefinition : EventReference, IMemberDefinition, ICustomAttributeProvider {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/EventDefinitionCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/EventDefinitionCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class EventDefinitionCollection : CollectionBase, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/EventReference.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/EventReference.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal abstract class EventReference : MemberReference {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ExternTypeCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ExternTypeCollection.cs
@@ -29,15 +29,15 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 	using System.Collections.Specialized;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
-	using Hcp = Mono.Cecil.HashCodeProvider;
+	using Hcp = CilStrip.Mono.Cecil.HashCodeProvider;
 	using Cmp = System.Collections.Comparer;
 
 	internal sealed class ExternTypeCollection : NameObjectCollectionBase, IList, IReflectionVisitable  {

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/FieldAttributes.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/FieldAttributes.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/FieldDefinition.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/FieldDefinition.cs
@@ -26,10 +26,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
-	using Mono.Cecil;
-	using Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil;
+	using CilStrip.Mono.Cecil.Binary;
 
 	internal sealed class FieldDefinition : FieldReference, IMemberDefinition,
 		ICustomAttributeProvider, IHasMarshalSpec, IHasConstant {

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/FieldDefinitionCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/FieldDefinitionCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class FieldDefinitionCollection : CollectionBase, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/FieldReference.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/FieldReference.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
-	using Mono.Cecil;
+	using CilStrip.Mono.Cecil;
 
 	internal class FieldReference : MemberReference {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/FileAttributes.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/FileAttributes.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal enum FileAttributes : uint {
 		ContainsMetaData	= 0x0000,	// This is not a resource file

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/FunctionPointerType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/FunctionPointerType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Text;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericArgumentCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericArgumentCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class GenericArgumentCollection : CollectionBase {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericContext.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericContext.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal class GenericContext {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericInstanceMethod.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericInstanceMethod.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Text;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericInstanceType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericInstanceType.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Text;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericParameter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericParameter.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericParameterAttributes.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericParameterAttributes.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericParameterCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/GenericParameterCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class GenericParameterCollection : CollectionBase, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/HashCodeProvider.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/HashCodeProvider.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Collections;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IAnnotationProvider.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IAnnotationProvider.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Collections;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IAssemblyResolver.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IAssemblyResolver.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IAssemblyResolver {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ICustomAttributeProvider.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ICustomAttributeProvider.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Reflection;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IDetailReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IDetailReader.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IDetailReader {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IGenericInstance.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IGenericInstance.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IGenericInstance : IMetadataTokenProvider {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IGenericParameterProvider.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IGenericParameterProvider.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IGenericParameterProvider : IMetadataTokenProvider {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IHasConstant.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IHasConstant.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IHasConstant : IMetadataTokenProvider {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IHasMarshalSpec.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IHasMarshalSpec.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IHasMarshalSpec : IMetadataTokenProvider {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IHasSecurity.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IHasSecurity.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IHasSecurity : IMetadataTokenProvider {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IImporter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IImporter.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IImporter {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IMemberDefinition.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IMemberDefinition.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IMemberDefinition : IMemberReference, ICustomAttributeProvider {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IMemberReference.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IMemberReference.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IMemberReference : IMetadataTokenProvider, IAnnotationProvider, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IMetadataScope.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IMetadataScope.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IMetadataScope : IMetadataTokenProvider {
 		string Name { get; set; }

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IMetadataTokenProvider.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IMetadataTokenProvider.cs
@@ -26,9 +26,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal interface IMetadataTokenProvider {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IMethodSignature.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IMethodSignature.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IMethodSignature {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IReflectionStructureVisitable.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IReflectionStructureVisitable.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IReflectionStructureVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IReflectionStructureVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IReflectionStructureVisitor.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IReflectionStructureVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IReflectionVisitable.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IReflectionVisitable.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IReflectionVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IReflectionVisitor.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IReflectionVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IRequireResolving.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/IRequireResolving.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal interface IRequireResolving {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ImportContext.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ImportContext.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal class ImportContext {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/InterfaceCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/InterfaceCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class InterfaceCollection : CollectionBase, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/LinkedResource.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/LinkedResource.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class LinkedResource : Resource {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ManifestResourceAttributes.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ManifestResourceAttributes.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MarshalSpec.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MarshalSpec.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MemberReference.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MemberReference.cs
@@ -26,11 +26,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Collections;
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal abstract class MemberReference : IMemberReference {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MemberReferenceCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MemberReferenceCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class MemberReferenceCollection : CollectionBase, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MetadataResolver.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MetadataResolver.cs
@@ -30,7 +30,7 @@
 using System;
 using System.Collections;
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	class MetadataResolver {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodAttributes.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodAttributes.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodCallingConvention.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodCallingConvention.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal enum MethodCallingConvention : byte {
 		Default		= 0x0,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodDefinition.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodDefinition.cs
@@ -26,10 +26,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
-	using Mono.Cecil.Binary;
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class MethodDefinition : MethodReference, IMemberDefinition,
 		IHasSecurity, ICustomAttributeProvider {

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodDefinitionCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodDefinitionCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class MethodDefinitionCollection : CollectionBase, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodImplAttributes.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodImplAttributes.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodReference.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodReference.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Text;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodReturnType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodReturnType.cs
@@ -28,9 +28,9 @@
 
 using System;
 
-using Mono.Cecil.Metadata;
+using CilStrip.Mono.Cecil.Metadata;
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class MethodReturnType : ICustomAttributeProvider, IHasMarshalSpec, IHasConstant {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodSemanticsAttributes.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodSemanticsAttributes.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodSpecification.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/MethodSpecification.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/Modifiers.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/Modifiers.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal abstract class ModType : TypeSpecification {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ModuleDefinition.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ModuleDefinition.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using SR = System.Reflection;
@@ -34,9 +34,9 @@ namespace Mono.Cecil {
 	using SSP = System.Security.Permissions;
 	using System.Text;
 
-	using Mono.Cecil.Cil;
-	using Mono.Cecil.Binary;
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class ModuleDefinition : ModuleReference, ICustomAttributeProvider, IMetadataScope,
 		IReflectionStructureVisitable, IReflectionVisitable {

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ModuleDefinitionCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ModuleDefinitionCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class ModuleDefinitionCollection : CollectionBase, IReflectionStructureVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ModuleReference.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ModuleReference.cs
@@ -26,12 +26,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Collections;
 
-	using Mono.Cecil;
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal class ModuleReference : IMetadataScope, IAnnotationProvider, IReflectionStructureVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ModuleReferenceCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ModuleReferenceCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class ModuleReferenceCollection : CollectionBase, IReflectionStructureVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/NativeType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/NativeType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal enum NativeType {
 		NONE = 0x66,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/NestedTypeCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/NestedTypeCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class NestedTypeCollection : CollectionBase, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/NullReferenceImporter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/NullReferenceImporter.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	sealed class NullReferenceImporter : IImporter {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/OverrideCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/OverrideCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class OverrideCollection : CollectionBase, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PInvokeAttributes.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PInvokeAttributes.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PInvokeInfo.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PInvokeInfo.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class PInvokeInfo : IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ParameterAttributes.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ParameterAttributes.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ParameterDefinition.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ParameterDefinition.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class ParameterDefinition : ParameterReference, IHasMarshalSpec,
 		IMetadataTokenProvider, ICustomAttributeProvider, IHasConstant {

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ParameterDefinitionCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ParameterDefinitionCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class ParameterDefinitionCollection : CollectionBase, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ParameterReference.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ParameterReference.cs
@@ -26,11 +26,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Collections;
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal abstract class ParameterReference : IMetadataTokenProvider, IAnnotationProvider, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PinnedType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PinnedType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class PinnedType : TypeSpecification {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PointerType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PointerType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class PointerType : TypeSpecification {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PropertyAttributes.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PropertyAttributes.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PropertyDefinition.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PropertyDefinition.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Text;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PropertyDefinitionCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PropertyDefinitionCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class PropertyDefinitionCollection : CollectionBase, IReflectionVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PropertyReference.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/PropertyReference.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal abstract class PropertyReference : MemberReference {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ReferenceType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ReferenceType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class ReferenceType : TypeSpecification {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ReflectionController.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ReflectionController.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class ReflectionController {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ReflectionException.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ReflectionException.cs
@@ -26,11 +26,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class ReflectionException : MetadataFormatException {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ReflectionHelper.cs
@@ -28,7 +28,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ReflectionReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ReflectionReader.cs
@@ -26,16 +26,16 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.IO;
 	using System.Text;
 
-	using Mono.Cecil.Binary;
-	using Mono.Cecil.Cil;
-	using Mono.Cecil.Metadata;
-	using Mono.Cecil.Signatures;
+	using CilStrip.Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Signatures;
 
 	internal abstract class ReflectionReader : BaseReflectionReader {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ReflectionWriter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ReflectionWriter.cs
@@ -26,17 +26,17 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 	using System.Globalization;
 	using System.Text;
 
-	using Mono.Cecil.Binary;
-	using Mono.Cecil.Cil;
-	using Mono.Cecil.Metadata;
-	using Mono.Cecil.Signatures;
+	using CilStrip.Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Signatures;
 
 	internal sealed class ReflectionWriter : BaseReflectionVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/Resource.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/Resource.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System.Collections;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ResourceCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/ResourceCollection.cs
@@ -29,12 +29,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
 	internal sealed class ResourceCollection : CollectionBase, IReflectionStructureVisitable {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/SecurityAction.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/SecurityAction.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal enum SecurityAction : short {
 		Request = 1,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/SecurityDeclaration.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/SecurityDeclaration.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/SecurityDeclarationCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/SecurityDeclarationCollection.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/SecurityDeclarationReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/SecurityDeclarationReader.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.IO;
@@ -35,9 +35,9 @@ namespace Mono.Cecil {
 	using SSP = System.Security.Permissions;
 	using System.Text;
 
-	using Mono.Cecil.Metadata;
-	using Mono.Cecil.Signatures;
-	using Mono.Xml;
+	using CilStrip.Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Signatures;
+	using CilStrip.Mono.Xml;
 
 	internal sealed class SecurityDeclarationReader {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/SentinelType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/SentinelType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class SentinelType : TypeSpecification {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/StructureReader.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/StructureReader.cs
@@ -26,13 +26,13 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.IO;
 
-	using Mono.Cecil.Binary;
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class StructureReader : BaseStructureVisitor {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/StructureWriter.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/StructureWriter.cs
@@ -26,13 +26,13 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.IO;
 
-	using Mono.Cecil.Binary;
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Binary;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	internal sealed class StructureWriter : BaseStructureVisitor {
 
@@ -162,7 +162,7 @@ namespace Mono.Cecil {
 		{
 			FileTable fTable = m_tableWriter.GetFileTable ();
 			FileRow fRow = m_rowWriter.CreateFileRow (
-				Mono.Cecil.FileAttributes.ContainsNoMetaData,
+				CilStrip.Mono.Cecil.FileAttributes.ContainsNoMetaData,
 				m_mdWriter.AddString (res.File),
 				m_mdWriter.AddBlob (res.Hash));
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TableComparers.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TableComparers.cs
@@ -26,12 +26,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 
-	using Mono.Cecil.Metadata;
+	using CilStrip.Mono.Cecil.Metadata;
 
 	sealed class TableComparers {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TargetRuntime.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TargetRuntime.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal enum TargetRuntime {
 		NET_1_0,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TypeAttributes.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TypeAttributes.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TypeDefinition.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TypeDefinition.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal sealed class TypeDefinition : TypeReference, IMemberDefinition, IHasSecurity {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TypeDefinitionCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TypeDefinitionCollection.cs
@@ -29,15 +29,15 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 	using System.Collections.Specialized;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
-	using Hcp = Mono.Cecil.HashCodeProvider;
+	using Hcp = CilStrip.Mono.Cecil.HashCodeProvider;
 	using Cmp = System.Collections.Comparer;
 
 	internal sealed class TypeDefinitionCollection : NameObjectCollectionBase, IList, IReflectionVisitable  {

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TypeReference.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TypeReference.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal class TypeReference : MemberReference, IGenericParameterProvider, ICustomAttributeProvider {
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TypeReferenceCollection.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TypeReferenceCollection.cs
@@ -29,15 +29,15 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 	using System.Collections;
 	using System.Collections.Specialized;
 
-	using Mono.Cecil.Cil;
+	using CilStrip.Mono.Cecil.Cil;
 
-	using Hcp = Mono.Cecil.HashCodeProvider;
+	using Hcp = CilStrip.Mono.Cecil.HashCodeProvider;
 	using Cmp = System.Collections.Comparer;
 
 	internal sealed class TypeReferenceCollection : NameObjectCollectionBase, IList, IReflectionVisitable  {

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TypeSpecification.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/TypeSpecification.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	using System;
 

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/VariantType.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/VariantType.cs
@@ -26,7 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-namespace Mono.Cecil {
+namespace CilStrip.Mono.Cecil {
 
 	internal enum VariantType {
 		I2 = 2,

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Xml/SecurityParser.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Xml/SecurityParser.cs
@@ -1,5 +1,5 @@
 //
-// Mono.Xml.SecurityParser.cs class implementation
+// CilStrip.Mono.Xml.SecurityParser.cs class implementation
 //
 // Author:
 //	Sebastien Pouliot (spouliot@motus.com)
@@ -35,7 +35,7 @@ using System.Collections;
 using System.IO;
 using System.Security;
 
-namespace Mono.Xml {
+namespace CilStrip.Mono.Xml {
 
 	// convert an XML document into SecurityElement objects
 	internal sealed class SecurityParser : SmallXmlParser, SmallXmlParser.IContentHandler {

--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Xml/SmallXmlParser.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Xml/SmallXmlParser.cs
@@ -36,7 +36,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 
-namespace Mono.Xml
+namespace CilStrip.Mono.Xml
 {
 	internal sealed class DefaultHandler : SmallXmlParser.IContentHandler
 	{


### PR DESCRIPTION
We hit a case where the ILStrip task assembly is IL-merged with a few other task assemblies on the Xamarin side which causes a clash because of trying to merge different Mono.Cecil versions.
Rename the Mono.Cecil used here to avoid that clash.

Backport of #169