### PR TITLE
[release/6.0] Fix corelib name in CilStrip source

### DIFF
--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/Constants.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil/Constants.cs
@@ -34,7 +34,7 @@ namespace CilStrip.Mono.Cecil {
 		{
 		}
 
-		public const string Corlib = "mscorlib";
+		public const string Corlib = "System.Private.CoreLib";
 
 		public const string ModuleType = "<Module>";
 		public const string PrivateImplDetails = "<PrivateImplementationDetails>";


### PR DESCRIPTION
We were using the old mscorlib name which causes issues when mscorlib is not linked away.

Backport of https://github.com/dotnet/runtime-assets/pull/176
