### PR TITLE
[release/5.0] Migrate to 1ES hosted pools

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -42,8 +42,8 @@ stages:
           ${{ if eq(variables._RunAsPublic, True) }}:
             vmimage: 'windows-latest'
           ${{ if eq(variables._RunAsInternal, True) }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2019
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
         strategy:
           matrix:
             Build_Release:


### PR DESCRIPTION
We are moving servicing to 1ES hosted pools. The functionality stays the same but yamls have to be updated.

Same change as for 6.0: https://github.com/dotnet/runtime-assets/pull/180