### PR TITLE
[build] Enable CodeQL with TSA

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\NET Runtime",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "runtimerepo-infra@microsoft.com" ],
+    "repositoryName": "runtime-assets",
+    "codebaseName": "runtime-assets"
+}

--- a/eng/pipelines/common-variables.yml
+++ b/eng/pipelines/common-variables.yml
@@ -28,3 +28,9 @@ variables:
         /p:DotNetPublishUsingPipelines=true
         /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+    - name: Codeql.Enabled
+      value: True
+    - name: Codeql.BuildIdentifier
+      value: $(System.JobDisplayName)
+    - name: Codeql.TSAEnabled
+      value: True


### PR DESCRIPTION
CodeQL is a static analysis tool that is able to scan source code to help detect security vulnerabilities. In Dotnet/runtime-assets, there already exists auto-injection of CodeQL's init and finalize tasks within the official default pipeline.

We enable CodeQL directly on the main pipeline as there are relatively few jobs, and because commits are relatively infrequent, there is no need for a separate pipeline to specify a cadence (periods between commits and therefore pipeline builds can be over a weeklong, so if there is no change, there is no need for a new codeql scan)

This PR  does the following:
Enables CodeQL
Enable TSA with CodeQL