### PR TITLE
[7.0] Update azure-pipelines.yml to use newest internal server

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -43,7 +43,7 @@ stages:
             vmimage: 'windows-latest'
           ${{ if eq(variables._RunAsInternal, True) }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+            demands: ImageOverride -equals windows.vs2022.amd64
         strategy:
           matrix:
             Build_Release:


### PR DESCRIPTION
Matches the one used in `main`: https://github.com/dotnet/runtime-assets/blob/3a8fb28f12af0c2c0b9eace35afafd689437c39e/eng/pipelines/azure-pipelines.yml#L46