### PR TITLE
Add codeql exclusions

### DIFF
--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -1,0 +1,10 @@
+path_classifiers:
+  test_data:
+    # *.TestData folders are not themselves shipping production or test code.
+    # Rather, they represent raw data intended to be processed by our tests.
+    # For more information, see:
+    # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/bugs/generated-library-code
+    - "src/*.TestData"
+    - "src/*.TimeZoneData"
+    - "src/*.UnicodeData"
+  

--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -7,4 +7,3 @@ path_classifiers:
     - "src/*.TestData"
     - "src/*.TimeZoneData"
     - "src/*.UnicodeData"
-  


### PR DESCRIPTION
Test data folders should be excluded from codeql analysis since they're not shipping production or test code.
