### PR TITLE
[7.0] Fix pool name in azure-pipelines.yml

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -27,7 +27,7 @@ extends:
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)\.config\CredScanSuppressions.json
       sourceAnalysisPool:
-        name: $(DncEngInternalBuildPool)
+        name: NetCore1ESPool-Svc-Internal
         image: 1es-windows-2022
         os: windows
     stages:


### PR DESCRIPTION
We can't use the variable in this branch.