### PR TITLE
Use default PublishingVersion and don't publish in Debug builds in public

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,6 +2,5 @@
   <PropertyGroup>
     <!-- Tells Arcade SDK to not assume that .nupkg contains Portable PDBs -->
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
-    <PublishingVersion>3</PublishingVersion>
   </PropertyGroup>
 </Project>

--- a/eng/pipelines/azure-pipelines-public.yml
+++ b/eng/pipelines/azure-pipelines-public.yml
@@ -44,10 +44,14 @@ stages:
           matrix:
             Build_Release:
               _BuildConfig: Release
+              _PublishArg: -publish
             Build_Debug:
               _BuildConfig: Debug
+              _PublishArg: ''
         steps:
-        - script: eng\common\cibuild.cmd
+        - script: .\build.cmd
+            -test -sign -pack -ci
+            $(_PublishArg)
             -configuration $(_BuildConfig)
             -prepareMachine
           displayName: Windows Build / Publish
@@ -57,15 +61,19 @@ stages:
           demands: ImageOverride -equals build.ubuntu.2204.amd64.open
         strategy:
           matrix:
-            Build_Debug:
-              _BuildConfig: Debug
             Build_Release:
               _BuildConfig: Release
+              _PublishArg: --publish
+            Build_Debug:
+              _BuildConfig: Debug
+              _PublishArg: ''
         preSteps:
         - checkout: self
           clean: true
         steps:
-        - script: eng/common/cibuild.sh
+        - script: ./build.sh
+            --test --pack --ci
+            $(_PublishArg)
             --configuration $(_BuildConfig)
             --prepareMachine
           displayName: Linux Build / Publish

--- a/eng/pipelines/azure-pipelines-public.yml
+++ b/eng/pipelines/azure-pipelines-public.yml
@@ -63,17 +63,14 @@ stages:
           matrix:
             Build_Release:
               _BuildConfig: Release
-              _PublishArg: --publish
             Build_Debug:
               _BuildConfig: Debug
-              _PublishArg: ''
         preSteps:
         - checkout: self
           clean: true
         steps:
         - script: ./build.sh
             --test --pack --ci
-            $(_PublishArg)
             --configuration $(_BuildConfig)
             --prepareMachine
-          displayName: Linux Build / Publish
+          displayName: Linux Build


### PR DESCRIPTION
Using cibuild.cmd/.sh is problematic since it passes the `-publish` flag which causes both Debug and Release legs to upload PackageArtifacts which sometimes causes an AzDO error.

Only publish in the Windows Release job in public, this is what we do for official builds anyway.