### PR TITLE
Upgrade to Arcade V4 publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <PublishingVersion>4</PublishingVersion>
     <!-- Tells Arcade SDK to not assume that .nupkg contains Portable PDBs -->
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
   </PropertyGroup>

--- a/eng/pipelines/azure-pipelines-public.yml
+++ b/eng/pipelines/azure-pipelines-public.yml
@@ -7,7 +7,7 @@ trigger:
   paths:
     exclude:
     - docs/*
-    
+
 pr:
   branches:
     include:
@@ -16,7 +16,7 @@ pr:
   paths:
     exclude:
     - docs/*
-    
+
 variables:
 - template: common-variables.yml
 - template: /eng/common/templates/variables/pool-providers.yml
@@ -33,9 +33,10 @@ stages:
           logs: true
           manifests: true
       enableMicrobuild: true
-      enablePublishUsingPipelines: true
+      publishingVersion: 4
       jobs:
       - job: Windows_NT
+        enablePublishing: true
         timeoutInMinutes: 90
         pool:
           name: $(DncEngPublicBuildPool)
@@ -56,6 +57,7 @@ stages:
             -prepareMachine
           displayName: Windows Build / Publish
       - job: Linux
+        enablePublishing: true
         pool:
           name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals build.ubuntu.2204.amd64.open

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -45,9 +45,10 @@ extends:
               logs: true
               manifests: true
           enableMicrobuild: true
-          enablePublishUsingPipelines: true
+          publishingVersion: 4
           jobs:
           - job: Windows_NT
+            enablePublishing: true
             timeoutInMinutes: 90
             pool:
               name: $(DncEngInternalBuildPool)
@@ -62,6 +63,7 @@ extends:
 
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
+        publishingInfraVersion: 4
         enableSourceLinkValidation: false
         enableSigningValidation: false
         symbolPublishingAdditionalParameters: /p:PublishToSymWeb=false /p:PublishToMSDL=false

--- a/eng/pipelines/common-variables.yml
+++ b/eng/pipelines/common-variables.yml
@@ -14,7 +14,6 @@ variables:
       value: real
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-        /p:DotNetPublishUsingPipelines=true
         /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
     - name: Codeql.Enabled


### PR DESCRIPTION
## Summary
- set `PublishingVersion` to 4 for repo-owned publishing props
- replace the legacy `enablePublishUsingPipelines` flow with V4 `publishingVersion`/`enablePublishing`
- update post-build validation to `publishingInfraVersion: 4`
- remove the stale `DotNetPublishUsingPipelines` build argument

## Validation
- parsed the updated Azure Pipelines YAML with PyYAML

Related to dotnet/arcade#16697.