### PR TITLE
[release/9.0] Don't download tzdb version file on every build

### DIFF
--- a/src/System.Runtime.TimeZoneData/System.Runtime.TimeZoneData.csproj
+++ b/src/System.Runtime.TimeZoneData/System.Runtime.TimeZoneData.csproj
@@ -29,7 +29,7 @@
       Overwrite="true"/>
   </Target>
   
-  <Target Name="GetLatestVersion" BeforeTargets="PrepareForBuild">
+  <Target Name="GetLatestVersion">
     <DownloadFile SourceUrl="https://data.iana.org/time-zones/tzdb/version"
                   DestinationFolder="$(TimeZoneDataIntermediateDir)">
       <Output TaskParameter="DownloadedFile" ItemName="VersionFile" />


### PR DESCRIPTION
Backport of #675 to `release/9.0`.

The `GetLatestVersion` target ran via `BeforeTargets="PrepareForBuild"`, causing every build to fetch `https://data.iana.org/time-zones/tzdb/version`. That network call isn't needed for normal builds — it's only relevant when bumping the tzdb version, which goes through the `UpdateToLatestVersion` → `SetLatestVersion` → `GetLatestVersion` dependency chain. Removing the `BeforeTargets` keeps the target reachable on demand while avoiding the per-build download (and the risk of a build break if IANA is unreachable).