### PR TITLE
[release/10.0] Fix IsPortableCodeView when rewriting assembly.

### DIFF
--- a/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/CopyImageVisitor.cs
+++ b/src/Microsoft.DotNet.CilStrip.Sources/src/Mono.Cecil.Binary/CopyImageVisitor.cs
@@ -53,8 +53,16 @@ namespace CilStrip.Mono.Cecil.Binary {
 			dbgHeader.Age = old.Age;
 			dbgHeader.Characteristics = old.Characteristics;
 			dbgHeader.FileName = old.FileName;
+			dbgHeader.MajorVersion = old.MajorVersion;
+			dbgHeader.MinorVersion = old.MinorVersion;
 			dbgHeader.Signature = old.Signature;
-			dbgHeader.TimeDateStamp = ImageInitializer.TimeDateStampFromEpoch();
+			// Portable PDBs (CodeView MinorVersion magic 0x504D) encode a content-derived stamp that
+			// is part of the PDB identity. Preserve it so the rewritten image keeps matching its
+			// unmodified PDB (IsPortableCodeView stays true and symbolication still works). Other
+			// debug entry kinds retain the historical behavior of a freshly generated stamp.
+			dbgHeader.TimeDateStamp = old.MinorVersion == 0x504D
+				? old.TimeDateStamp
+				: ImageInitializer.TimeDateStampFromEpoch();
 			dbgHeader.Type = old.Type;
 		}
 


### PR DESCRIPTION
Current rewrite of the debug directory didn't copy over the Minor/MajorVersion, making portable PDBs not work as intended (IsPortableCodeView returned false). It also reset the timestamp, incorrect in the portable PDB scenario as well, since that field is not a real timestamp but the low 4 bytes of the PDB content id (part of the PDB identity).

Fix makes sure to copy Minor/MajorVersion from old, as well as the timestamp when dealing with portable PDBs. For full PDBs all works as before: Minor/MajorVersion will be 0 and the timestamp is regenerated.

Backport of https://github.com/dotnet/runtime-assets/pull/688